### PR TITLE
Improvements in repeated calls to setup functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build/
 .*.~undo-tree~
 logging-example
 .clpm/
+*.fasl

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -9,5 +9,12 @@
                               "ASDF"
                               "REPL"
                               "HTTP"))
+  (0.2.0 2024-11-20
+         "
+## Changed
+
+* Now  40ants-logging:setup-for-backend function and 40ants-logging:setup-for-cli function keep nested loggers. This way you will not loose setup made by Log4SLY or Log4SLYNK interactively.
+* Also, setup functions now keeps original appender's stream, which prevents from occational disruption of the base logging process.
+")
   (0.1.0 2023-02-05
          "* Initial version."))

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -8,12 +8,14 @@
 (defchangelog (:ignore-words ("SLY"
                               "ASDF"
                               "REPL"
+                              "LOG4SLY"
+                              "LOG4SLYNK"
                               "HTTP"))
   (0.2.0 2024-11-20
          "
 ## Changed
 
-* Now  40ants-logging:setup-for-backend function and 40ants-logging:setup-for-cli function keep nested loggers. This way you will not loose setup made by Log4SLY or Log4SLYNK interactively.
+* Now 40ANTS-LOGGING:SETUP-FOR-BACKEND function and 40ANTS-LOGGING:SETUP-FOR-CLI function keep nested loggers. This way you will not loose setup made by LOG4SLY or LOG4SLYNK interactively.
 * Also, setup functions now keeps original appender's stream, which prevents from occational disruption of the base logging process.
 ")
   (0.1.0 2023-02-05

--- a/qlfile
+++ b/qlfile
@@ -1,4 +1,4 @@
-dist ultralisp http://dist.ultralisp.org/
+dist ultralisp https://dist.ultralisp.org/
 
 # This branch is what I use in my Emacs.
-github slynk svetlyak40wt/sly :branch patches
+# github slynk svetlyak40wt/sly :branch patches

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,0 +1,8 @@
+("quicklisp" .
+ (:class qlot/source/dist:source-dist
+  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2024-10-12"))
+("ultralisp" .
+ (:class qlot/source/dist:source-dist
+  :initargs (:distribution "https://dist.ultralisp.org/" :%version :latest)
+  :version "20241119195000"))

--- a/roswell/example.ros
+++ b/roswell/example.ros
@@ -1,0 +1,20 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+(progn ;;init forms
+  (ros:ensure-asdf)
+  #+quicklisp
+  (ql:quickload '(40ants-logging-example/cli)
+                :silent t)
+  )
+
+(defpackage :ros.script.example
+  (:use :cl)
+  (:import-from #:40ants-logging-example/cli
+                #:main))
+(in-package :ros.script.example)
+
+
+;;; vim: set ft=lisp lisp:

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -13,10 +13,26 @@
 
 (define-global-var *core-appenders* nil)
 
+(define-global-var *repl-appenders* nil)
+
 (define-global-var *default-level* :warn)
 
 (define-global-var *level* nil
   "Level given to the last call to SETUP-FOR-BACKEND or SETUP-FOR-CLI functions.")
+
+
+(defun get-original-stream ()
+  (getf (cdr (first *core-appenders*))
+        :stream))
+
+
+(defun resolve-synonyms (stream)
+  (typecase stream
+    (synonym-stream
+       (resolve-synonyms
+        (symbol-value (synonym-stream-symbol stream))))
+    (t
+       stream)))
 
 
 (defun setup-for-backend (&key (level *default-level*))
@@ -24,30 +40,83 @@
   (setf *level* level)
   (setf *core-appenders*
         (list (list 'this-console
-                    :stream *standard-output*
+                    :stream (or (get-original-stream)
+                                (resolve-synonyms *standard-output*))
                     :layout :json
                     :filter level)))
   
-  (log4cl-extras/config:setup
-   (list :level :debug
-         :appenders *core-appenders*)))
+  (let ((children (log4cl::%logger-child-hash log4cl:*root-logger*))
+        (orig-root-logger log4cl:*root-logger*))
+    (log:info "Changing" orig-root-logger)
+
+
+    ;; We need to setup
+    (setf (log4cl::%logger-child-hash log4cl:*root-logger*)
+          (make-hash-table :test 'equal))
+    
+    (log4cl-extras/config:setup
+     (list :level :debug
+           :appenders (append *repl-appenders*
+                              *core-appenders*)))
+    ;; Here we need to restore children because the might be
+    ;; changed interactively using LOG4SLIME or LOG4SLY and we don't
+    ;; want to loose these settings:
+    (setf (log4cl::%logger-child-hash log4cl:*root-logger*)
+          children))
+  (values))
+
+
+(defun setup-for-cli (&key (level *default-level*))
+  "Configures LOG4CL for logging in plain-text format with context fields support."
+  (when *core-appenders*
+    (error "Base logging setup already done. Use SET-BASE-LEVEL or SET-REPL-LEVEL to change log levels."))
+  
+  (setf *level* level)
+  (setf *core-appenders*
+        (list (list 'this-console
+                    ;; Here we keep original stream
+                    ;; captured by the first run of setup-for-cli or setup-for-repl
+                    :stream (or (get-original-stream)
+                                (resolve-synonyms *standard-output*))
+                    :layout :plain
+                    :filter level)))
+  (let ((children (log4cl::%logger-child-hash log4cl:*root-logger*)))
+    (log4cl-extras/config:setup
+     (list :level :debug
+           :appenders (append *repl-appenders*
+                              *core-appenders*)))
+    ;; Here we need to restore children because the might be
+    ;; changed interactively using LOG4SLIME or LOG4SLY and we don't
+    ;; want to loose these settings:
+    (setf (log4cl::%logger-child-hash log4cl:*root-logger*)
+          children))
+  (values))
 
 
 (defun setup-for-repl (&key (level *level*)
-                            (stream *debug-io*))
+                       (stream *debug-io*))
   "Configures LOG4CL for logging in REPL when you connect to the running lisp image already configured as a backend or CLI application.
 
    If you are using 40ANTS-SLYNK system, this function will be called automatically
    when your SLY connects to the image."
-  (let ((appenders
-          (list* (list 'this-console
-                       :stream stream
-                       :layout :plain
-                       :filter level)
-                 *core-appenders*)))
+  (setf *repl-appenders*
+        (list
+         (list 'this-console
+               :stream (resolve-synonyms stream)
+               :layout :plain
+               :filter level)))
+  
+  (let ((children (log4cl::%logger-child-hash log4cl:*root-logger*)))
     (log4cl-extras/config:setup
      (list :level :debug
-           :appenders appenders))))
+           :appenders (append *repl-appenders*
+                              *core-appenders*)))
+    ;; Here we need to restore children because the might be
+    ;; changed interactively using LOG4SLIME or LOG4SLY and we don't
+    ;; want to loose these settings:
+    (setf (log4cl::%logger-child-hash log4cl:*root-logger*)
+          children))
+  (values))
 
 
 (defun remove-repl-appender ()
@@ -58,15 +127,3 @@
   (log4cl-extras/config:setup
      (list :level :debug
            :appenders *core-appenders*)))
-
-
-(defun setup-for-cli (&key (level *default-level*))
-  "Configures LOG4CL for logging in plain-text format with context fields support."
-  (setf *level* level)
-  (setf *core-appenders*
-        (list (list 'this-console
-                    :layout :plain
-                    :filter level)))
-  (log4cl-extras/config:setup
-   (list :level :debug
-         :appenders *core-appenders*)))


### PR DESCRIPTION
* Now  40ants-logging:setup-for-backend function and 40ants-logging:setup-for-cli function keep nested loggers. This way you will not loose setup made by Log4SLY or Log4SLYNK interactively.
* Also, setup functions now keeps original appender's stream, which prevents from occational disruption of the base logging process